### PR TITLE
DRAFT: dynamic draws

### DIFF
--- a/jaxlogit/_optimize.py
+++ b/jaxlogit/_optimize.py
@@ -115,7 +115,7 @@ def gradient(funct, x, *args):
     return grad
 
 
-def hessian(funct, x, hessian_by_row, *args):
+def hessian(funct, x, hessian_by_row, finite_diff, *args):
     """Compute the Hessian of funct for variables x."""
 
     # # this is memory intensive for large x.
@@ -124,16 +124,31 @@ def hessian(funct, x, hessian_by_row, *args):
 
     grad_funct = jax.jit(jax.grad(funct, argnums=0), static_argnames=STATIC_LOGLIKE_ARGNAMES)
 
-    def row(i):
-        return jax.grad(lambda x_: grad_funct(x_, *args)[i])(x)
-
-    if not hessian_by_row:
-        H = jax.vmap(row)(jnp.arange(x.size))
-    # slower but less memory intensive - hessian_by_row in for loop
-    else:
+    # This is a compromise between memory and speed - we know jax gradient calculations are
+    # within memory limits because we use it during minimization, to stay within the smae
+    # memory limits we use finite differences on the jitted grad.
+    if finite_diff:
+        eps = 1e-6
         H = jnp.empty((len(x), len(x)))
         for i in range(len(x)):
-            hess_row = row(i)
+            x_plus = x.at[i].set(x[i] + eps)
+            x_minus = x.at[i].set(x[i] - eps)
+            grad_plus = grad_funct(x_plus, *args)  # gradient(funct, x_plus, *args) for full FD
+            grad_minus = grad_funct(x_minus, *args)
+            hess_row = (grad_plus - grad_minus) / (2 * eps)
             H = H.at[i, :].set(hess_row)
+    else:
+
+        def row(i):
+            return jax.grad(lambda x_: grad_funct(x_, *args)[i])(x)
+
+        if not hessian_by_row:
+            H = jax.vmap(row)(jnp.arange(x.size))
+        # slower but less memory intensive - hessian_by_row in for loop
+        else:
+            H = jnp.empty((len(x), len(x)))
+            for i in range(len(x)):
+                hess_row = row(i)
+                H = H.at[i, :].set(hess_row)
 
     return H

--- a/jaxlogit/_optimize.py
+++ b/jaxlogit/_optimize.py
@@ -10,7 +10,7 @@ from scipy.optimize import minimize
 logger = logging.getLogger(__name__)
 
 # static_argnames in loglikelihood function, TODO: maybe replace with partial and get rid of all additional args
-STATIC_LOGLIKE_ARGNAMES = ["num_panels", "include_correlations", "force_positive_chol_diag", "batch_size"]
+STATIC_LOGLIKE_ARGNAMES = ["draws", "num_panels", "include_correlations", "force_positive_chol_diag", "batch_size"]
 
 
 def _minimize(loglik_fn, x, args, method, tol, options, bounds=None):

--- a/jaxlogit/_optimize.py
+++ b/jaxlogit/_optimize.py
@@ -10,7 +10,14 @@ from scipy.optimize import minimize
 logger = logging.getLogger(__name__)
 
 # static_argnames in loglikelihood function, TODO: maybe replace with partial and get rid of all additional args
-STATIC_LOGLIKE_ARGNAMES = ["draws", "num_panels", "include_correlations", "force_positive_chol_diag", "batch_size"]
+STATIC_LOGLIKE_ARGNAMES = [
+    "draws",
+    "num_panels",
+    "include_correlations",
+    "force_positive_chol_diag",
+    "num_batches",
+    "batch_shape",
+]
 
 
 def _minimize(loglik_fn, x, args, method, tol, options, bounds=None):

--- a/jaxlogit/_optimize.py
+++ b/jaxlogit/_optimize.py
@@ -17,8 +17,7 @@ def _minimize(loglik_fn, x, args, method, tol, options, bounds=None):
     logger.info(f"Running minimization with method {method}")
 
     if method in ["L-BFGS-B", "BFGS"]:
-        # neg_loglik_and_grad = jax.jit(jax.value_and_grad(loglik_fn, argnums=0), static_argnames=STATIC_LOGLIKE_ARGNAMES)
-        neg_loglik_and_grad = jax.value_and_grad(loglik_fn, argnums=0)
+        neg_loglik_and_grad = jax.jit(jax.value_and_grad(loglik_fn, argnums=0), static_argnames=STATIC_LOGLIKE_ARGNAMES)
         def neg_loglike_scipy(betas, *args):
             """Wrapper for neg_loglike to use with scipy."""
             x = jnp.array(betas)
@@ -116,8 +115,7 @@ def hessian(funct, x, hessian_by_row, *args):
     #hess_fn = jax.jacfwd(jax.grad(funct))  # jax.hessian(neg_loglike)
     #H = hess_fn(jnp.array(x), *args)
 
-    # grad_funct = jax.jit(jax.grad(funct, argnums=0), static_argnames=STATIC_LOGLIKE_ARGNAMES)
-    grad_funct = jax.grad(funct, argnums=0)
+    grad_funct = jax.jit(jax.grad(funct, argnums=0), static_argnames=STATIC_LOGLIKE_ARGNAMES)
 
     def row(i):
         return jax.grad(lambda x_: grad_funct(x_, *args)[i])(x)

--- a/jaxlogit/_optimize.py
+++ b/jaxlogit/_optimize.py
@@ -17,8 +17,8 @@ def _minimize(loglik_fn, x, args, method, tol, options, bounds=None):
     logger.info(f"Running minimization with method {method}")
 
     if method in ["L-BFGS-B", "BFGS"]:
+        # neg_loglik_and_grad = jax.jit(jax.value_and_grad(loglik_fn, argnums=0), static_argnames=STATIC_LOGLIKE_ARGNAMES)
         neg_loglik_and_grad = jax.value_and_grad(loglik_fn, argnums=0)
-        neg_loglik_and_grad = jax.jit(neg_loglik_and_grad, static_argnames=STATIC_LOGLIKE_ARGNAMES)
         def neg_loglike_scipy(betas, *args):
             """Wrapper for neg_loglike to use with scipy."""
             x = jnp.array(betas)
@@ -116,7 +116,8 @@ def hessian(funct, x, hessian_by_row, *args):
     #hess_fn = jax.jacfwd(jax.grad(funct))  # jax.hessian(neg_loglike)
     #H = hess_fn(jnp.array(x), *args)
 
-    grad_funct = jax.jit(jax.grad(funct, argnums=0), static_argnames=STATIC_LOGLIKE_ARGNAMES)
+    # grad_funct = jax.jit(jax.grad(funct, argnums=0), static_argnames=STATIC_LOGLIKE_ARGNAMES)
+    grad_funct = jax.grad(funct, argnums=0)
 
     def row(i):
         return jax.grad(lambda x_: grad_funct(x_, *args)[i])(x)

--- a/jaxlogit/draws.py
+++ b/jaxlogit/draws.py
@@ -7,6 +7,79 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+## currently a pr at https://github.com/jax-ml/jax/pull/23808/files
+def _newton_raphson(f, x, iters):
+    """Use the Newton-Raphson method to find a root of the given function."""
+
+    def update(x, _):
+        y = x - f(x) / jax.grad(f)(x)
+        return y, None
+
+    x, _ = jax.lax.scan(update, x, length=iters)
+    return x
+
+
+def roberts_sequence(
+    num: int,
+    dim: int,
+    root_iters: int = 10_000,
+    complement_basis: bool = True,
+    key=None,  ## ArrayLike | None = None,
+    perturb: bool = False,
+    shuffle: bool = False,
+    dtype=float,  # DTypeLikeFloat = float,
+):
+    """Returns the Roberts sequence, a low-discrepancy quasi-random sequence:
+    Low-discrepancy sequences are useful for quasi-Monte Carlo methods.
+    Reference:
+    Martin Roberts. The Unreasonable Effectiveness of Quasirandom Sequences.
+    extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences
+    Args:
+      num: Number of points to return.
+      dim: The dimensionality of each point in the sequence.
+      root_iters: Number of iterations to use to find the root.
+      complement_basis: Complement the basis to improve precision, as described
+        in https://www.martysmods.com/a-better-r2-sequence.
+      key: a PRNG key.
+      perturb: Apply a uniformly random perturbation to the entire sequence,
+        followed by modulo 1.
+      shuffle: Shuffle the elements of the sequence before returning them.
+        Warning: This degrades the low-discrepancy property for prefixes of
+        the output sequence.
+      dtype: optional, a float dtype for the returned values (default float64 if
+        jax_enable_x64 is true, otherwise float32).
+    Returns:
+      An array of shape (num, dim) containing the sequence.
+    """
+
+    def f(x):
+        return x ** (dim + 1) - x - 1
+
+    root = _newton_raphson(f, jnp.astype(1.0, dtype), root_iters)
+
+    basis = 1 / root ** (1 + jnp.arange(dim, dtype=dtype))
+
+    if complement_basis:
+        basis = 1 - basis
+
+    n = jnp.arange(num, dtype=dtype)
+    x = n[:, None] * basis[None, :]
+
+    if perturb:
+        if key is None:
+            raise ValueError("key for roberts_sequence cannot be None when perturb=True")
+        key, subkey = jax.random.split(key)
+        x += jax.random.uniform(subkey, (dim,), dtype)[None]
+
+    x, _ = jnp.modf(x)
+
+    if shuffle:
+        if key is None:
+            raise ValueError("key for roberts_sequence cannot be None when shuffle=True")
+        x = jax.random.permutation(key, x)
+
+    return x
+
 
 # TODO: have a look at scipy.stats.qmc, has sobol draws
 def generate_draws(sample_size, n_draws, _rvdist, halton=True, halton_opts=None):

--- a/jaxlogit/draws.py
+++ b/jaxlogit/draws.py
@@ -170,10 +170,11 @@ def van_der_corput_jax(k, base=2, perm=None):
     return val
 
 
-def halton_seq_jax(length, base=2, drop=0, shuffle=False, key=None, scramble=False, perm=None):
-    # idxs = jnp.arange(length + drop)[drop:]
-    MAX_DRAW = 100_000_000_000_000
-    idxs = jax.lax.dynamic_slice(jnp.arange(MAX_DRAW), (drop,), (length,))
+def halton_seq_jax(length, base=2, drop=0, shuffle=False, key=None, scramble=False, perm=None, idxs=None):
+    if idxs is None:
+        idxs = jnp.arange(length + drop)[drop:]
+    # MAX_DRAW = 100_000_000_000_000
+    # idxs = jax.lax.dynamic_slice(jnp.arange(MAX_DRAW), (drop,), (length,))
     if scramble:
         if perm is None:
             raise ValueError("A permutation array must be provided for scrambling.")
@@ -188,7 +189,9 @@ def halton_seq_jax(length, base=2, drop=0, shuffle=False, key=None, scramble=Fal
 
 
 # @partial(jax.jit, static_argnames=["sample_size", "n_draws", "n_vars"])
-def get_normal_halton_draws_jax(sample_size, n_draws, n_vars, drop=100, shuffle=False, key=None, primes=None):
+def get_normal_halton_draws_jax(
+    sample_size, n_draws, n_vars, drop=100, shuffle=False, key=None, primes=None, idxs=None
+):
     if primes is None:
         primes = jnp.array(
             [
@@ -274,7 +277,7 @@ def get_normal_halton_draws_jax(sample_size, n_draws, n_vars, drop=100, shuffle=
         #         sample_size * n_draws, base, drop=drop, shuffle=shuffle, key=k, scramble=True, perm=perm
         #     )
         # else:
-        seq = halton_seq_jax(sample_size * n_draws, base, drop=drop, shuffle=shuffle, key=k)
+        seq = halton_seq_jax(sample_size * n_draws, base, drop=drop, shuffle=shuffle, key=k, idxs=idxs)
         return jax.scipy.stats.norm.ppf(seq.reshape(sample_size, n_draws))
 
     draws = jax.vmap(one_var)(jnp.arange(n_vars))

--- a/jaxlogit/draws.py
+++ b/jaxlogit/draws.py
@@ -8,8 +8,7 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
-# TODO: move draws to a separate file, add/use scipy.stats.qmc
-# TODO: dynamically on each iteration
+# TODO: have a look at scipy.stats.qmc, has sobol draws
 def generate_draws(sample_size, n_draws, _rvdist, halton=True, halton_opts=None):
     """Generate draws based on the given mixing distributions."""
     if halton:

--- a/jaxlogit/draws.py
+++ b/jaxlogit/draws.py
@@ -1,0 +1,151 @@
+import logging
+
+import jax
+import jax.numpy as jnp
+import jax.scipy.stats as jstats
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+# TODO: move draws to a separate file, add/use scipy.stats.qmc
+# TODO: dynamically on each iteration
+def generate_draws(sample_size, n_draws, _rvdist, halton=True, halton_opts=None):
+    """Generate draws based on the given mixing distributions."""
+    if halton:
+        draws = generate_halton_draws(
+            sample_size,
+            n_draws,
+            len(_rvdist),
+            **halton_opts if halton_opts is not None else {},
+        )
+    else:
+        draws = generate_random_draws(sample_size, n_draws, len(_rvdist))
+
+    for k, dist in enumerate(_rvdist):
+        if dist in ["n", "ln"]:  # Normal based
+            draws[:, k, :] = jstats.norm.ppf(draws[:, k, :])
+        # elif dist == "t":  # Triangular
+        #     draws_k = draws[:, k, :]
+        #     draws[:, k, :] = (np.sqrt(2 * draws_k) - 1) * (draws_k <= 0.5) + (1 - np.sqrt(2 * (1 - draws_k))) * (
+        #         draws_k > 0.5
+        #     )
+        # elif dist == "u":  # Uniform
+        #     draws[:, k, :] = 2 * draws[:, k, :] - 1
+        else:
+            raise ValueError(f"Mixing distribution {dist} for random variable {k} not implemented yet.")
+
+    return draws  # (N,Kr,R)
+
+
+def generate_random_draws(sample_size, n_draws, n_vars):
+    """Generate random uniform draws between 0 and 1."""
+    return np.random.uniform(size=(sample_size, n_vars, n_draws))
+
+
+def generate_halton_draws(sample_size, n_draws, n_vars, shuffle=False, drop=100, primes=None):
+    """Generate Halton draws for multiple random variables using different primes as base"""
+    if primes is None:
+        primes = [
+            2,
+            3,
+            5,
+            7,
+            11,
+            13,
+            17,
+            19,
+            23,
+            29,
+            31,
+            37,
+            41,
+            43,
+            47,
+            53,
+            59,
+            61,
+            71,
+            73,
+            79,
+            83,
+            89,
+            97,
+            101,
+            103,
+            107,
+            109,
+            113,
+            127,
+            131,
+            137,
+            139,
+            149,
+            151,
+            157,
+            163,
+            167,
+            173,
+            179,
+            181,
+            191,
+            193,
+            197,
+            199,
+            211,
+            223,
+            227,
+            229,
+            233,
+            239,
+            241,
+            251,
+            257,
+            263,
+            269,
+            271,
+            277,
+            281,
+            283,
+            293,
+            307,
+            311,
+        ]
+
+    def halton_seq(length, prime=3, shuffle=False, drop=100):
+        """Generates a halton sequence while handling memory efficiently.
+
+        Memory is efficiently handled by creating a single array ``seq`` that is iteratively filled without using
+        intermidiate arrays.
+        """
+        req_length = length + drop
+        seq = np.empty(req_length)
+        seq[0] = 0
+        seq_idx = 1
+        t = 1
+        while seq_idx < req_length:
+            d = 1 / prime**t
+            seq_size = seq_idx
+            i = 1
+            while i < prime and seq_idx < req_length:
+                max_seq = min(req_length - seq_idx, seq_size)
+                seq[seq_idx : seq_idx + max_seq] = seq[:max_seq] + d * i
+                seq_idx += max_seq
+                i += 1
+            t += 1
+        seq = seq[drop : length + drop]
+        if shuffle:
+            np.random.shuffle(seq)
+        return seq
+
+    draws = [
+        halton_seq(
+            sample_size * n_draws,
+            prime=primes[i % len(primes)],
+            shuffle=shuffle,
+            drop=drop,
+        ).reshape(sample_size, n_draws)
+        for i in range(n_vars)
+    ]
+    draws = np.stack(draws, axis=1)
+    return draws  # (N,Kr,R)

--- a/jaxlogit/mixed_logit.py
+++ b/jaxlogit/mixed_logit.py
@@ -824,7 +824,8 @@ def loglike_individual(
         ## n_samples = N if panels is None else np.max(panels) + 1
         ## draws = generate_draws(n_samples, n_draws, self._rvdist, halton, halton_opts=halton_opts)
         ## draws = draws if panels is None else draws[panels]  # (N,num_random_params,n_draws)
-        draws_batched = draws_batched if panels is None else draws_batched[panels]
+        if panels is not None:
+            draws_batched = draws_batched[panels]
 
         # Utility for random parameters
         Br = _transform_rand_betas(
@@ -845,7 +846,8 @@ def loglike_individual(
         if scale_d is not None:
             Vd = Vd - (betas[-1] * scale_d)[:, :, None]
         eVd = jnp.exp(jnp.clip(Vd, -UTIL_MAX, UTIL_MAX))
-        eVd = eVd if avail is None else eVd * avail[:, :, None]
+        if avail is not None:
+            eVd = eVd * avail[:, :, None]
         proba_n = 1 / (1 + eVd.sum(axis=1))  # (N,R)
 
         if panels is not None:

--- a/jaxlogit/mixed_logit.py
+++ b/jaxlogit/mixed_logit.py
@@ -491,7 +491,12 @@ class MixedLogit(ChoiceModel):
         logger.info(f"Init loglike = {-init_loglike:.2f}.")
 
         init_grad = jax.jacfwd(neg_loglike, argnums=0)(betas, *fargs)
-        logger.info(f"Init gradient norm = {jnp.linalg.norm(init_grad):.2f}.")
+        init_grad_norm = jax.lax.stop_gradient(jnp.linalg.norm(init_grad))
+        logger.info(f"Init gradient_fwd norm = {init_grad_norm:.2f}, shape of grad = {init_grad.shape}.")
+
+        init_grad = jax.grad(neg_loglike, argnums=0)(betas, *fargs)
+        init_grad_norm = jax.lax.stop_gradient(jnp.linalg.norm(init_grad))
+        logger.info(f"Init gradient_bwd norm = {init_grad_norm:.2f}, shape of grad = {init_grad.shape}.")
 
         optim_res = _minimize(
             neg_loglike,

--- a/jaxlogit/mixed_logit.py
+++ b/jaxlogit/mixed_logit.py
@@ -489,13 +489,9 @@ class MixedLogit(ChoiceModel):
 
         init_loglike = neg_loglike(betas, *fargs)
         logger.info(f"Init loglike = {-init_loglike:.2f}.")
-
-        # init_grad = jax.jacfwd(neg_loglike, argnums=0)(betas, *fargs)
+        # init_grad = jax.grad(neg_loglike, argnums=0)(betas, *fargs)
         # init_grad_norm = jax.lax.stop_gradient(jnp.linalg.norm(init_grad))
-        # logger.info(f"Init gradient_fwd norm = {init_grad_norm:.2f}, shape of grad = {init_grad.shape}.")
-        init_grad = jax.grad(neg_loglike, argnums=0)(betas, *fargs)
-        init_grad_norm = jax.lax.stop_gradient(jnp.linalg.norm(init_grad))
-        logger.info(f"Init gradient norm = {init_grad_norm:.2f}, shape of grad = {init_grad.shape}.")
+        # logger.info(f"Init gradient norm = {init_grad_norm:.2f}, shape of grad = {init_grad.shape}.")
 
         optim_res = _minimize(
             neg_loglike,

--- a/jaxlogit/mixed_logit.py
+++ b/jaxlogit/mixed_logit.py
@@ -490,13 +490,12 @@ class MixedLogit(ChoiceModel):
         init_loglike = neg_loglike(betas, *fargs)
         logger.info(f"Init loglike = {-init_loglike:.2f}.")
 
-        init_grad = jax.jacfwd(neg_loglike, argnums=0)(betas, *fargs)
-        init_grad_norm = jax.lax.stop_gradient(jnp.linalg.norm(init_grad))
-        logger.info(f"Init gradient_fwd norm = {init_grad_norm:.2f}, shape of grad = {init_grad.shape}.")
-
+        # init_grad = jax.jacfwd(neg_loglike, argnums=0)(betas, *fargs)
+        # init_grad_norm = jax.lax.stop_gradient(jnp.linalg.norm(init_grad))
+        # logger.info(f"Init gradient_fwd norm = {init_grad_norm:.2f}, shape of grad = {init_grad.shape}.")
         init_grad = jax.grad(neg_loglike, argnums=0)(betas, *fargs)
         init_grad_norm = jax.lax.stop_gradient(jnp.linalg.norm(init_grad))
-        logger.info(f"Init gradient_bwd norm = {init_grad_norm:.2f}, shape of grad = {init_grad.shape}.")
+        logger.info(f"Init gradient norm = {init_grad_norm:.2f}, shape of grad = {init_grad.shape}.")
 
         optim_res = _minimize(
             neg_loglike,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,10 @@ devtools = [
     'setuptools',
     'uv',
     'ipywidgets',
-    'jupyterlab'
+    'jupyterlab',
+    'tensorboard',
+    'xprof',
+    ' tensorflow',
 ]
 tests = [
     'pytest',


### PR DESCRIPTION
In the current implementation, random draws are generated once upfront and then used throughout estimation. I ran into out of memory issues for a large model - about 80k observations for 13 variables and 10k draws leads to an array of size 77GB with 64bit precision, and gradient calculations are performed on top. We here introduce batching of calculations over draws with dynamic re-drawing for every log-likelihood calculation. This preserves memory at the cost of runtime. Note that the underlying loop over batches utilizes jax.lax.scan to avoid unrolling inside jit.
I am using this work on large scale models, but I am marking this PR as draft because it needs proper integration for un-batched estimation - it is much slower here than on main because of the constant re-drawing of random numbers which is only necessary for batched calculations.