### PR TITLE
Dynamic calculation of draws, enabling batching

### DIFF
--- a/examples/batching_example.ipynb
+++ b/examples/batching_example.ipynb
@@ -1,0 +1,642 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TJHlxbR5kEe-"
+      },
+      "source": [
+        "# Example of running jaxlogit with batched draws\n",
+        "\n",
+        "jaxlogit's default way of processing random draws for simulation is to generate them once at the beginning and then run calculate the loglikelihood at each step of the optimization routine with these draws. The size of the corresponding array is (number_of_observations x number_of_random_variables x  number_of_draws) which can get very large. In case tnis is too large for local memory, jaxlogit can dynamcially generate draws on each iteration. The advantage of this is that calculations can now be batched, i.e., processed on smaller subsets and then added up. This reduces memory load that the cost of runtime. Note that jax still calculates gradients so this method also has memory limits."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%load_ext memory_profiler"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "NQbZt7CVh8f_",
+        "outputId": "b823e80f-fd47-4dd1-8656-3fd0d6a1e26a"
+      },
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "import jax\n",
+        "\n",
+        "from jaxlogit.mixed_logit import MixedLogit"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "#  64bit precision\n",
+        "jax.config.update(\"jax_enable_x64\", True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Electricity Dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "df = pd.read_csv(\"https://raw.github.com/arteagac/xlogit/master/examples/data/electricity_long.csv\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Data has 4308 observations, we use 6 random variables in the model. We work in 64 bit precision, so each element is 8 bytes. For 5000 draws, the array of draws is about 0.96 GB.\n"
+          ]
+        }
+      ],
+      "source": [
+        "n_obs = df['chid'].unique().shape[0]\n",
+        "n_vars = 6\n",
+        "n_draws = 5000\n",
+        "\n",
+        "size_in_ram = (n_obs * n_vars * n_draws * 8) / (1024 ** 3)  # in GB\n",
+        "\n",
+        "print(\n",
+        "    f\"Data has {n_obs} observations, we use {n_vars} random variables in the model. We work in 64 bit precision, so each element is 8 bytes.\"\n",
+        "    + f\" For {n_draws} draws, the array of draws is about {size_in_ram:.2f} GB.\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/usr/lib/python3.10/multiprocessing/popen_fork.py:66: RuntimeWarning: os.fork() was called. os.fork() is incompatible with multithreaded code, and JAX is multithreaded, so this will likely lead to a deadlock.\n",
+            "  self.pid = os.fork()\n",
+            "2025-08-02 06:50:58,584 INFO jaxlogit.mixed_logit: Number of draws: 5000.\n",
+            "2025-08-02 06:50:58,585 INFO jaxlogit.mixed_logit: Data contains 361 panels.\n",
+            "2025-08-02 06:50:58,585 INFO jaxlogit._optimize: Running minimization with method trust-region\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Loss on this step: 5398.76049331062, Loss on the last accepted step: 0.0, Step size: 1.0\n",
+            "Loss on this step: 228458.86628940978, Loss on the last accepted step: 5398.76049331062, Step size: 0.25\n",
+            "Loss on this step: 160451.46329785584, Loss on the last accepted step: 5398.76049331062, Step size: 0.0625\n",
+            "Loss on this step: 50414.41638847614, Loss on the last accepted step: 5398.76049331062, Step size: 0.015625\n",
+            "Loss on this step: 12744.479542385374, Loss on the last accepted step: 5398.76049331062, Step size: 0.00390625\n",
+            "Loss on this step: 4876.005292732634, Loss on the last accepted step: 5398.76049331062, Step size: 0.00390625\n",
+            "Loss on this step: 12433.663557121343, Loss on the last accepted step: 4876.005292732634, Step size: 0.0009765625\n",
+            "Loss on this step: 4805.104927545437, Loss on the last accepted step: 4876.005292732634, Step size: 0.0009765625\n",
+            "Loss on this step: 4727.152504373395, Loss on the last accepted step: 4805.104927545437, Step size: 0.0009765625\n",
+            "Loss on this step: 4745.130706009277, Loss on the last accepted step: 4727.152504373395, Step size: 0.000244140625\n",
+            "Loss on this step: 4689.561698161982, Loss on the last accepted step: 4727.152504373395, Step size: 0.000244140625\n",
+            "Loss on this step: 4675.446876672622, Loss on the last accepted step: 4689.561698161982, Step size: 0.000244140625\n",
+            "Loss on this step: 4663.240563290156, Loss on the last accepted step: 4675.446876672622, Step size: 0.000244140625\n",
+            "Loss on this step: 4622.233983742649, Loss on the last accepted step: 4663.240563290156, Step size: 0.000244140625\n",
+            "Loss on this step: 4603.349021539365, Loss on the last accepted step: 4622.233983742649, Step size: 0.000244140625\n",
+            "Loss on this step: 4594.807669899441, Loss on the last accepted step: 4603.349021539365, Step size: 0.000244140625\n",
+            "Loss on this step: 4579.650566095627, Loss on the last accepted step: 4594.807669899441, Step size: 0.0008544921875\n",
+            "Loss on this step: 4558.918536311823, Loss on the last accepted step: 4579.650566095627, Step size: 0.0008544921875\n",
+            "Loss on this step: 4528.684645021705, Loss on the last accepted step: 4558.918536311823, Step size: 0.0008544921875\n",
+            "Loss on this step: 4512.319046965582, Loss on the last accepted step: 4528.684645021705, Step size: 0.0008544921875\n",
+            "Loss on this step: 4491.045295075372, Loss on the last accepted step: 4512.319046965582, Step size: 0.0008544921875\n",
+            "Loss on this step: 4476.536846712964, Loss on the last accepted step: 4491.045295075372, Step size: 0.0008544921875\n",
+            "Loss on this step: 4459.77365634273, Loss on the last accepted step: 4476.536846712964, Step size: 0.0008544921875\n",
+            "Loss on this step: 4448.627044901105, Loss on the last accepted step: 4459.77365634273, Step size: 0.0008544921875\n",
+            "Loss on this step: 4434.80850508923, Loss on the last accepted step: 4448.627044901105, Step size: 0.0008544921875\n",
+            "Loss on this step: 4424.941421694152, Loss on the last accepted step: 4434.80850508923, Step size: 0.0008544921875\n",
+            "Loss on this step: 4413.031826385426, Loss on the last accepted step: 4424.941421694152, Step size: 0.0008544921875\n",
+            "Loss on this step: 4404.589524368567, Loss on the last accepted step: 4413.031826385426, Step size: 0.0008544921875\n",
+            "Loss on this step: 4394.143365485693, Loss on the last accepted step: 4404.589524368567, Step size: 0.0008544921875\n",
+            "Loss on this step: 4386.579710298989, Loss on the last accepted step: 4394.143365485693, Step size: 0.00299072265625\n",
+            "Loss on this step: 4358.310074572864, Loss on the last accepted step: 4386.579710298989, Step size: 0.00299072265625\n",
+            "Loss on this step: 4338.620099420116, Loss on the last accepted step: 4358.310074572864, Step size: 0.00299072265625\n",
+            "Loss on this step: 4323.405522462117, Loss on the last accepted step: 4338.620099420116, Step size: 0.00299072265625\n",
+            "Loss on this step: 4304.706927230513, Loss on the last accepted step: 4323.405522462117, Step size: 0.00299072265625\n",
+            "Loss on this step: 4291.504795918125, Loss on the last accepted step: 4304.706927230513, Step size: 0.00299072265625\n",
+            "Loss on this step: 4281.396713000642, Loss on the last accepted step: 4291.504795918125, Step size: 0.00299072265625\n",
+            "Loss on this step: 4269.904665352162, Loss on the last accepted step: 4281.396713000642, Step size: 0.00299072265625\n",
+            "Loss on this step: 4261.194674757467, Loss on the last accepted step: 4269.904665352162, Step size: 0.00299072265625\n",
+            "Loss on this step: 4251.669168349139, Loss on the last accepted step: 4261.194674757467, Step size: 0.00299072265625\n",
+            "Loss on this step: 4244.345485296046, Loss on the last accepted step: 4251.669168349139, Step size: 0.010467529296875\n",
+            "Loss on this step: 4219.631537046729, Loss on the last accepted step: 4244.345485296046, Step size: 0.010467529296875\n",
+            "Loss on this step: 4200.868087439283, Loss on the last accepted step: 4219.631537046729, Step size: 0.010467529296875\n",
+            "Loss on this step: 4175.737365049495, Loss on the last accepted step: 4200.868087439283, Step size: 0.010467529296875\n",
+            "Loss on this step: 4160.689986259888, Loss on the last accepted step: 4175.737365049495, Step size: 0.010467529296875\n",
+            "Loss on this step: 4145.463746329002, Loss on the last accepted step: 4160.689986259888, Step size: 0.010467529296875\n",
+            "Loss on this step: 4130.721016224257, Loss on the last accepted step: 4145.463746329002, Step size: 0.010467529296875\n",
+            "Loss on this step: 4127.704353296081, Loss on the last accepted step: 4130.721016224257, Step size: 0.010467529296875\n",
+            "Loss on this step: 4101.665644528677, Loss on the last accepted step: 4127.704353296081, Step size: 0.010467529296875\n",
+            "Loss on this step: 4091.2229215490834, Loss on the last accepted step: 4101.665644528677, Step size: 0.010467529296875\n",
+            "Loss on this step: 4082.3369829861836, Loss on the last accepted step: 4091.2229215490834, Step size: 0.010467529296875\n",
+            "Loss on this step: 4076.01438860756, Loss on the last accepted step: 4082.3369829861836, Step size: 0.010467529296875\n",
+            "Loss on this step: 4069.388194428345, Loss on the last accepted step: 4076.01438860756, Step size: 0.010467529296875\n",
+            "Loss on this step: 4064.104990315801, Loss on the last accepted step: 4069.388194428345, Step size: 0.010467529296875\n",
+            "Loss on this step: 4058.4740684437775, Loss on the last accepted step: 4064.104990315801, Step size: 0.0366363525390625\n",
+            "Loss on this step: 4043.8733442205494, Loss on the last accepted step: 4058.4740684437775, Step size: 0.0366363525390625\n",
+            "Loss on this step: 4026.172351476708, Loss on the last accepted step: 4043.8733442205494, Step size: 0.0366363525390625\n",
+            "Loss on this step: 4039.8870828042377, Loss on the last accepted step: 4026.172351476708, Step size: 0.009159088134765625\n",
+            "Loss on this step: 4037.448856906839, Loss on the last accepted step: 4026.172351476708, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4022.645222879493, Loss on the last accepted step: 4026.172351476708, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4020.4432222904916, Loss on the last accepted step: 4022.645222879493, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4018.482464012488, Loss on the last accepted step: 4020.4432222904916, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4013.1492226140376, Loss on the last accepted step: 4018.482464012488, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4007.3223549233862, Loss on the last accepted step: 4013.1492226140376, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4003.9591581326004, Loss on the last accepted step: 4007.3223549233862, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4000.053592086343, Loss on the last accepted step: 4003.9591581326004, Step size: 0.028049707412719727\n",
+            "Loss on this step: 3990.6442077539987, Loss on the last accepted step: 4000.053592086343, Step size: 0.028049707412719727\n",
+            "Loss on this step: 3982.261969719347, Loss on the last accepted step: 3990.6442077539987, Step size: 0.028049707412719727\n",
+            "Loss on this step: 3966.8427455026413, Loss on the last accepted step: 3982.261969719347, Step size: 0.028049707412719727\n",
+            "Loss on this step: 3968.8576105110237, Loss on the last accepted step: 3966.8427455026413, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3964.6611319663984, Loss on the last accepted step: 3966.8427455026413, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3961.038898107852, Loss on the last accepted step: 3964.6611319663984, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3958.71475722656, Loss on the last accepted step: 3961.038898107852, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3956.855214442555, Loss on the last accepted step: 3958.71475722656, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3955.3328054258072, Loss on the last accepted step: 3956.855214442555, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3953.848497551666, Loss on the last accepted step: 3955.3328054258072, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3952.607225083904, Loss on the last accepted step: 3953.848497551666, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3951.4220473403752, Loss on the last accepted step: 3952.607225083904, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3950.3509682055733, Loss on the last accepted step: 3951.4220473403752, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3949.271993380671, Loss on the last accepted step: 3950.3509682055733, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3948.2769064731824, Loss on the last accepted step: 3949.271993380671, Step size: 0.007012426853179932\n",
+            "Loss on this step: 3947.306962178598, Loss on the last accepted step: 3948.2769064731824, Step size: 0.02454349398612976\n",
+            "Loss on this step: 3944.072113547311, Loss on the last accepted step: 3947.306962178598, Step size: 0.08590222895145416\n",
+            "Loss on this step: 3934.648530634265, Loss on the last accepted step: 3944.072113547311, Step size: 0.08590222895145416\n",
+            "Loss on this step: 3998.8820218394217, Loss on the last accepted step: 3934.648530634265, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3928.2055444733837, Loss on the last accepted step: 3934.648530634265, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3928.798999985827, Loss on the last accepted step: 3928.2055444733837, Step size: 0.005368889309465885\n",
+            "Loss on this step: 3928.2519597933756, Loss on the last accepted step: 3928.2055444733837, Step size: 0.0013422223273664713\n",
+            "Loss on this step: 3927.8003680910947, Loss on the last accepted step: 3928.2055444733837, Step size: 0.0013422223273664713\n",
+            "Loss on this step: 3927.4349068555734, Loss on the last accepted step: 3927.8003680910947, Step size: 0.0046977781457826495\n",
+            "Loss on this step: 3926.0685424138746, Loss on the last accepted step: 3927.4349068555734, Step size: 0.016442223510239273\n",
+            "Loss on this step: 3923.865800293798, Loss on the last accepted step: 3926.0685424138746, Step size: 0.016442223510239273\n",
+            "Loss on this step: 3919.776854597229, Loss on the last accepted step: 3923.865800293798, Step size: 0.016442223510239273\n",
+            "Loss on this step: 3918.33194352507, Loss on the last accepted step: 3919.776854597229, Step size: 0.016442223510239273\n",
+            "Loss on this step: 3916.8124881445287, Loss on the last accepted step: 3918.33194352507, Step size: 0.016442223510239273\n",
+            "Loss on this step: 3915.5245076307183, Loss on the last accepted step: 3916.8124881445287, Step size: 0.016442223510239273\n",
+            "Loss on this step: 3914.2473482854293, Loss on the last accepted step: 3915.5245076307183, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3910.72808169472, Loss on the last accepted step: 3914.2473482854293, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3905.517614662239, Loss on the last accepted step: 3910.72808169472, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3902.2871438428792, Loss on the last accepted step: 3905.517614662239, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3898.8480371879605, Loss on the last accepted step: 3902.2871438428792, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3896.544567779764, Loss on the last accepted step: 3898.8480371879605, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3893.59278065177, Loss on the last accepted step: 3896.544567779764, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3891.739329385645, Loss on the last accepted step: 3893.59278065177, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3890.000371788414, Loss on the last accepted step: 3891.739329385645, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3888.4324572600317, Loss on the last accepted step: 3890.000371788414, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3887.457427948283, Loss on the last accepted step: 3888.4324572600317, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3886.534220402019, Loss on the last accepted step: 3887.457427948283, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3885.710186452284, Loss on the last accepted step: 3886.534220402019, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3884.529539004939, Loss on the last accepted step: 3885.710186452284, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3883.9931903324814, Loss on the last accepted step: 3884.529539004939, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3883.547184628807, Loss on the last accepted step: 3883.9931903324814, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3883.145308342857, Loss on the last accepted step: 3883.547184628807, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3882.7789239682875, Loss on the last accepted step: 3883.145308342857, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3882.527427730596, Loss on the last accepted step: 3882.7789239682875, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3882.2436319332214, Loss on the last accepted step: 3882.527427730596, Step size: 0.05754778228583746\n",
+            "Loss on this step: 3882.0183790432948, Loss on the last accepted step: 3882.2436319332214, Step size: 0.2014172380004311\n",
+            "Loss on this step: 3881.369900372574, Loss on the last accepted step: 3882.0183790432948, Step size: 0.7049603330015088\n",
+            "Loss on this step: 3880.648623491479, Loss on the last accepted step: 3881.369900372574, Step size: 0.7049603330015088\n",
+            "Loss on this step: 3881.048683599792, Loss on the last accepted step: 3880.648623491479, Step size: 0.1762400832503772\n",
+            "Loss on this step: 3880.2967546855875, Loss on the last accepted step: 3880.648623491479, Step size: 0.1762400832503772\n",
+            "Loss on this step: 3880.2331130317893, Loss on the last accepted step: 3880.2967546855875, Step size: 0.1762400832503772\n",
+            "Loss on this step: 3880.2129537468873, Loss on the last accepted step: 3880.2331130317893, Step size: 0.1762400832503772\n",
+            "Loss on this step: 3880.2020963016157, Loss on the last accepted step: 3880.2129537468873, Step size: 0.1762400832503772\n",
+            "Loss on this step: 3880.194963809337, Loss on the last accepted step: 3880.2020963016157, Step size: 0.1762400832503772\n",
+            "Loss on this step: 3880.1909770822685, Loss on the last accepted step: 3880.194963809337, Step size: 0.6168402913763202\n",
+            "Loss on this step: 3880.1853253574914, Loss on the last accepted step: 3880.1909770822685, Step size: 0.6168402913763202\n",
+            "Loss on this step: 3880.184740198896, Loss on the last accepted step: 3880.1853253574914, Step size: 0.6168402913763202\n",
+            "Loss on this step: 3880.1843875391264, Loss on the last accepted step: 3880.184740198896, Step size: 0.6168402913763202\n",
+            "Loss on this step: 3880.184371132295, Loss on the last accepted step: 3880.1843875391264, Step size: 0.6168402913763202\n",
+            "Loss on this step: 3880.1843683405805, Loss on the last accepted step: 3880.184371132295, Step size: 0.6168402913763202\n",
+            "Loss on this step: 3880.184368132378, Loss on the last accepted step: 3880.1843683405805, Step size: 0.6168402913763202\n",
+            "Loss on this step: 3880.184368096075, Loss on the last accepted step: 3880.184368132378, Step size: 2.158941019817121\n",
+            "Loss on this step: 3880.184368090931, Loss on the last accepted step: 3880.184368096075, Step size: 2.158941019817121\n",
+            "Loss on this step: 3880.1843680906823, Loss on the last accepted step: 3880.184368090931, Step size: 2.158941019817121\n",
+            "Loss on this step: 3880.1843680903594, Loss on the last accepted step: 3880.1843680906823, Step size: 7.556293569359923\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "2025-08-02 06:53:08,366 INFO jaxlogit.mixed_logit: Optimization finished, success = True, final loglike = -3880.18, final gradient max = 3.52e-05, norm = 3.71e-05.\n",
+            "2025-08-02 06:53:08,367 INFO jaxlogit.mixed_logit: Skipping H_inv and grad_n calculation due to skip_std_errs=True\n",
+            "2025-08-02 06:53:08,367 INFO jaxlogit._choice_model: Post fit processing\n",
+            "2025-08-02 06:53:08,480 INFO jaxlogit._choice_model: Optimization terminated successfully.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "    Message: \n",
+            "    Iterations: 122\n",
+            "    Function evaluations: 135\n",
+            "Estimation time= 131.9 seconds\n",
+            "---------------------------------------------------------------------------\n",
+            "Coefficient              Estimate      Std.Err.         z-val         P>|z|\n",
+            "---------------------------------------------------------------------------\n",
+            "pf                     -1.0166190     1.0000000    -1.0166190         0.309    \n",
+            "cl                     -0.2327734     1.0000000    -0.2327734         0.816    \n",
+            "loc                     2.3556396     1.0000000     2.3556396        0.0185 *  \n",
+            "wk                      1.6744863     1.0000000     1.6744863        0.0941 .  \n",
+            "tod                    -9.7531221     1.0000000    -9.7531221      3.03e-22 ***\n",
+            "seas                   -9.9133439     1.0000000    -9.9133439       6.4e-23 ***\n",
+            "sd.pf                  -1.3452418     1.0000000    -1.3452418         0.179    \n",
+            "sd.cl                  -0.6834247     1.0000000    -0.6834247         0.494    \n",
+            "sd.loc                  1.7530060     1.0000000     1.7530060        0.0797 .  \n",
+            "sd.wk                   0.9325520     1.0000000     0.9325520         0.351    \n",
+            "sd.tod                  2.3503011     1.0000000     2.3503011        0.0188 *  \n",
+            "sd.seas                 1.2937872     1.0000000     1.2937872         0.196    \n",
+            "---------------------------------------------------------------------------\n",
+            "Significance:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1\n",
+            "\n",
+            "Log-Likelihood= -3880.184\n",
+            "AIC= 7784.369\n",
+            "BIC= 7860.787\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "None"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/usr/lib/python3.10/multiprocessing/popen_fork.py:66: RuntimeWarning: os.fork() was called. os.fork() is incompatible with multithreaded code, and JAX is multithreaded, so this will likely lead to a deadlock.\n",
+            "  self.pid = os.fork()\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "peak memory: 16300.37 MiB, increment: 13227.84 MiB\n"
+          ]
+        }
+      ],
+      "source": [
+        "%%memit\n",
+        "\n",
+        "model = MixedLogit()\n",
+        "res = model.fit(\n",
+        "    X=df[varnames],\n",
+        "    y=df['choice'],\n",
+        "    varnames=varnames,\n",
+        "    ids=df['chid'],\n",
+        "    panels=df['id'],\n",
+        "    alts=df['alt'],\n",
+        "    n_draws=n_draws,\n",
+        "    randvars={'pf': 'n', 'cl': 'n', 'loc': 'n', 'wk': 'n', 'tod': 'n', 'seas': 'n'},\n",
+        "    skip_std_errs=True,  # skip standard errors to speed up the example\n",
+        ")\n",
+        "display(model.summary())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Now with batching"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/usr/lib/python3.10/multiprocessing/popen_fork.py:66: RuntimeWarning: os.fork() was called. os.fork() is incompatible with multithreaded code, and JAX is multithreaded, so this will likely lead to a deadlock.\n",
+            "  self.pid = os.fork()\n",
+            "2025-08-02 06:53:37,059 INFO jaxlogit.mixed_logit: Batch size 2500 for 5000 draws, 2 batches, batch_shape=(361, 6, 2500).\n",
+            "2025-08-02 06:53:37,253 INFO jaxlogit.mixed_logit: Shape of halton_rand_idxs: (2, 902500), last row: [ 902600  902601  902602 ... 1805097 1805098 1805099].\n",
+            "2025-08-02 06:53:37,254 INFO jaxlogit.mixed_logit: Data contains 361 panels.\n",
+            "2025-08-02 06:53:37,255 INFO jaxlogit._optimize: Running minimization with method trust-region\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Loss on this step: 5400.574956968836, Loss on the last accepted step: 0.0, Step size: 1.0\n",
+            "Loss on this step: 236205.1987293798, Loss on the last accepted step: 5400.574956968836, Step size: 0.25\n",
+            "Loss on this step: 179328.5462734287, Loss on the last accepted step: 5400.574956968836, Step size: 0.0625\n",
+            "Loss on this step: 60138.966668619876, Loss on the last accepted step: 5400.574956968836, Step size: 0.015625\n",
+            "Loss on this step: 15029.725330006007, Loss on the last accepted step: 5400.574956968836, Step size: 0.00390625\n",
+            "Loss on this step: 4902.1301395825285, Loss on the last accepted step: 5400.574956968836, Step size: 0.00390625\n",
+            "Loss on this step: 23906.99970969664, Loss on the last accepted step: 4902.1301395825285, Step size: 0.0009765625\n",
+            "Loss on this step: 5000.272332071836, Loss on the last accepted step: 4902.1301395825285, Step size: 0.000244140625\n",
+            "Loss on this step: 4818.005552007051, Loss on the last accepted step: 4902.1301395825285, Step size: 0.000244140625\n",
+            "Loss on this step: 4779.406971042665, Loss on the last accepted step: 4818.005552007051, Step size: 0.000244140625\n",
+            "Loss on this step: 4735.163632507533, Loss on the last accepted step: 4779.406971042665, Step size: 0.000244140625\n",
+            "Loss on this step: 4718.674711025754, Loss on the last accepted step: 4735.163632507533, Step size: 0.0008544921875\n",
+            "Loss on this step: 4684.009130377072, Loss on the last accepted step: 4718.674711025754, Step size: 0.00299072265625\n",
+            "Loss on this step: 4600.152056102427, Loss on the last accepted step: 4684.009130377072, Step size: 0.00299072265625\n",
+            "Loss on this step: 4526.739050992635, Loss on the last accepted step: 4600.152056102427, Step size: 0.00299072265625\n",
+            "Loss on this step: 6330.888136309752, Loss on the last accepted step: 4526.739050992635, Step size: 0.0007476806640625\n",
+            "Loss on this step: 4573.002332259912, Loss on the last accepted step: 4526.739050992635, Step size: 0.000186920166015625\n",
+            "Loss on this step: 4519.292821293944, Loss on the last accepted step: 4526.739050992635, Step size: 0.000186920166015625\n",
+            "Loss on this step: 4513.836413498384, Loss on the last accepted step: 4519.292821293944, Step size: 0.000186920166015625\n",
+            "Loss on this step: 4509.429026589273, Loss on the last accepted step: 4513.836413498384, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4496.49236576239, Loss on the last accepted step: 4509.429026589273, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4488.359749694894, Loss on the last accepted step: 4496.49236576239, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4476.180112115504, Loss on the last accepted step: 4488.359749694894, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4469.336917187276, Loss on the last accepted step: 4476.180112115504, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4459.020861053106, Loss on the last accepted step: 4469.336917187276, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4452.409159117893, Loss on the last accepted step: 4459.020861053106, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4443.174961749329, Loss on the last accepted step: 4452.409159117893, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4437.1581354719965, Loss on the last accepted step: 4443.174961749329, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4428.857635219871, Loss on the last accepted step: 4437.1581354719965, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4423.285044656267, Loss on the last accepted step: 4428.857635219871, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4415.722877506751, Loss on the last accepted step: 4423.285044656267, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4410.544198665866, Loss on the last accepted step: 4415.722877506751, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4403.600101630791, Loss on the last accepted step: 4410.544198665866, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4398.762350010816, Loss on the last accepted step: 4403.600101630791, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4392.339076783164, Loss on the last accepted step: 4398.762350010816, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4387.79910479491, Loss on the last accepted step: 4392.339076783164, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4381.820945753411, Loss on the last accepted step: 4387.79910479491, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4377.542833762096, Loss on the last accepted step: 4381.820945753411, Step size: 0.0006542205810546875\n",
+            "Loss on this step: 4371.949380849643, Loss on the last accepted step: 4377.542833762096, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4354.909577446928, Loss on the last accepted step: 4371.949380849643, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4341.1812308188355, Loss on the last accepted step: 4354.909577446928, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4330.852363717539, Loss on the last accepted step: 4341.1812308188355, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4320.355454016782, Loss on the last accepted step: 4330.852363717539, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4312.053893401358, Loss on the last accepted step: 4320.355454016782, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4303.495297390111, Loss on the last accepted step: 4312.053893401358, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4295.999318497194, Loss on the last accepted step: 4303.495297390111, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4288.419258715077, Loss on the last accepted step: 4295.999318497194, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4281.981700600724, Loss on the last accepted step: 4288.419258715077, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4275.454290117197, Loss on the last accepted step: 4281.981700600724, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4269.4715552395755, Loss on the last accepted step: 4275.454290117197, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4263.519441352692, Loss on the last accepted step: 4269.4715552395755, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4258.170605551389, Loss on the last accepted step: 4263.519441352692, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4252.781891463837, Loss on the last accepted step: 4258.170605551389, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4247.801907713075, Loss on the last accepted step: 4252.781891463837, Step size: 0.0022897720336914062\n",
+            "Loss on this step: 4242.803223362619, Loss on the last accepted step: 4247.801907713075, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4227.122743042479, Loss on the last accepted step: 4242.803223362619, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4214.573000727579, Loss on the last accepted step: 4227.122743042479, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4197.03147761756, Loss on the last accepted step: 4214.573000727579, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4191.734952527998, Loss on the last accepted step: 4197.03147761756, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4178.5646060894915, Loss on the last accepted step: 4191.734952527998, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4167.487357105536, Loss on the last accepted step: 4178.5646060894915, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4154.99112576896, Loss on the last accepted step: 4167.487357105536, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4149.479991234386, Loss on the last accepted step: 4154.99112576896, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4139.236197476005, Loss on the last accepted step: 4149.479991234386, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4131.441717945974, Loss on the last accepted step: 4139.236197476005, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4124.165027763038, Loss on the last accepted step: 4131.441717945974, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4117.017412242919, Loss on the last accepted step: 4124.165027763038, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4108.639294110113, Loss on the last accepted step: 4117.017412242919, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4100.728925739492, Loss on the last accepted step: 4108.639294110113, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4095.006726277359, Loss on the last accepted step: 4100.728925739492, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4090.818193246418, Loss on the last accepted step: 4095.006726277359, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4086.259867437008, Loss on the last accepted step: 4090.818193246418, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4082.397302503397, Loss on the last accepted step: 4086.259867437008, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4078.3595850953543, Loss on the last accepted step: 4082.397302503397, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4074.7915756302004, Loss on the last accepted step: 4078.3595850953543, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4071.1047074238877, Loss on the last accepted step: 4074.7915756302004, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4067.5592028150354, Loss on the last accepted step: 4071.1047074238877, Step size: 0.008014202117919922\n",
+            "Loss on this step: 4064.2153450436463, Loss on the last accepted step: 4067.5592028150354, Step size: 0.028049707412719727\n",
+            "Loss on this step: 4054.22222268864, Loss on the last accepted step: 4064.2153450436463, Step size: 0.028049707412719727\n",
+            "Loss on this step: 4030.603028066818, Loss on the last accepted step: 4054.22222268864, Step size: 0.028049707412719727\n",
+            "Loss on this step: 4051.432499865043, Loss on the last accepted step: 4030.603028066818, Step size: 0.007012426853179932\n",
+            "Loss on this step: 4035.4615736809446, Loss on the last accepted step: 4030.603028066818, Step size: 0.001753106713294983\n",
+            "Loss on this step: 4027.849750012434, Loss on the last accepted step: 4030.603028066818, Step size: 0.001753106713294983\n",
+            "Loss on this step: 4026.5305924035474, Loss on the last accepted step: 4027.849750012434, Step size: 0.00613587349653244\n",
+            "Loss on this step: 4023.8047345521218, Loss on the last accepted step: 4026.5305924035474, Step size: 0.00613587349653244\n",
+            "Loss on this step: 4019.4077566722713, Loss on the last accepted step: 4023.8047345521218, Step size: 0.00613587349653244\n",
+            "Loss on this step: 4017.492700558381, Loss on the last accepted step: 4019.4077566722713, Step size: 0.00613587349653244\n",
+            "Loss on this step: 4014.383839975031, Loss on the last accepted step: 4017.492700558381, Step size: 0.02147555723786354\n",
+            "Loss on this step: 4007.46055324089, Loss on the last accepted step: 4014.383839975031, Step size: 0.02147555723786354\n",
+            "Loss on this step: 4000.134320316928, Loss on the last accepted step: 4007.46055324089, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3994.4624041931706, Loss on the last accepted step: 4000.134320316928, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3988.113057737895, Loss on the last accepted step: 3994.4624041931706, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3982.3557353185065, Loss on the last accepted step: 3988.113057737895, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3974.914856939825, Loss on the last accepted step: 3982.3557353185065, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3971.0091448437465, Loss on the last accepted step: 3974.914856939825, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3961.347754436377, Loss on the last accepted step: 3971.0091448437465, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3957.3826471029115, Loss on the last accepted step: 3961.347754436377, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3954.20419100855, Loss on the last accepted step: 3957.3826471029115, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3951.0462148819474, Loss on the last accepted step: 3954.20419100855, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3947.913913891182, Loss on the last accepted step: 3951.0462148819474, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3944.8573042670437, Loss on the last accepted step: 3947.913913891182, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3941.9420905349343, Loss on the last accepted step: 3944.8573042670437, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3938.797697942661, Loss on the last accepted step: 3941.9420905349343, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3936.023010174096, Loss on the last accepted step: 3938.797697942661, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3933.6071013351593, Loss on the last accepted step: 3936.023010174096, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3931.2188783693987, Loss on the last accepted step: 3933.6071013351593, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3929.057917801135, Loss on the last accepted step: 3931.2188783693987, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3927.0725637837227, Loss on the last accepted step: 3929.057917801135, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3924.971053135173, Loss on the last accepted step: 3927.0725637837227, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3922.8854146293847, Loss on the last accepted step: 3924.971053135173, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3921.0819886874287, Loss on the last accepted step: 3922.8854146293847, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3919.2629953555065, Loss on the last accepted step: 3921.0819886874287, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3917.7034833860125, Loss on the last accepted step: 3919.2629953555065, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3916.2336640045187, Loss on the last accepted step: 3917.7034833860125, Step size: 0.02147555723786354\n",
+            "Loss on this step: 3914.824011336778, Loss on the last accepted step: 3916.2336640045187, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3910.457274174633, Loss on the last accepted step: 3914.824011336778, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3905.105477249953, Loss on the last accepted step: 3910.457274174633, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3899.742629150326, Loss on the last accepted step: 3905.105477249953, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3895.1551866808477, Loss on the last accepted step: 3899.742629150326, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3892.993428904055, Loss on the last accepted step: 3895.1551866808477, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3890.8439005282494, Loss on the last accepted step: 3892.993428904055, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3889.271949430733, Loss on the last accepted step: 3890.8439005282494, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3887.446605555746, Loss on the last accepted step: 3889.271949430733, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3886.111691974657, Loss on the last accepted step: 3887.446605555746, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3884.8808919462595, Loss on the last accepted step: 3886.111691974657, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3884.0649467787453, Loss on the last accepted step: 3884.8808919462595, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3883.4302558450345, Loss on the last accepted step: 3884.0649467787453, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3882.8532891224745, Loss on the last accepted step: 3883.4302558450345, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3882.319255764732, Loss on the last accepted step: 3882.8532891224745, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3881.897391839093, Loss on the last accepted step: 3882.319255764732, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3881.538609102288, Loss on the last accepted step: 3881.897391839093, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3881.237800626689, Loss on the last accepted step: 3881.538609102288, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3881.0150074186527, Loss on the last accepted step: 3881.237800626689, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3880.8462135488685, Loss on the last accepted step: 3881.0150074186527, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3880.6959565644493, Loss on the last accepted step: 3880.8462135488685, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3880.566605918674, Loss on the last accepted step: 3880.6959565644493, Step size: 0.07516445033252239\n",
+            "Loss on this step: 3880.4653416299693, Loss on the last accepted step: 3880.566605918674, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3880.2110006982266, Loss on the last accepted step: 3880.4653416299693, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3880.06460850506, Loss on the last accepted step: 3880.2110006982266, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.97298675717, Loss on the last accepted step: 3880.06460850506, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.9387999546716, Loss on the last accepted step: 3879.97298675717, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.926173880201, Loss on the last accepted step: 3879.9387999546716, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.921912320213, Loss on the last accepted step: 3879.926173880201, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.920230148874, Loss on the last accepted step: 3879.921912320213, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.919230033481, Loss on the last accepted step: 3879.920230148874, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.918786523747, Loss on the last accepted step: 3879.919230033481, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.91856156352, Loss on the last accepted step: 3879.918786523747, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.918434150548, Loss on the last accepted step: 3879.91856156352, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.918370786197, Loss on the last accepted step: 3879.918434150548, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.9183414765057, Loss on the last accepted step: 3879.918370786197, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.9183263927066, Loss on the last accepted step: 3879.9183414765057, Step size: 0.2630755761638284\n",
+            "Loss on this step: 3879.918318675511, Loss on the last accepted step: 3879.9183263927066, Step size: 0.9207645165733993\n",
+            "Loss on this step: 3879.9183100420746, Loss on the last accepted step: 3879.918318675511, Step size: 0.9207645165733993\n",
+            "Loss on this step: 3879.9183099694806, Loss on the last accepted step: 3879.9183100420746, Step size: 0.9207645165733993\n",
+            "Loss on this step: 3879.9183099589045, Loss on the last accepted step: 3879.9183099694806, Step size: 0.9207645165733993\n",
+            "Loss on this step: 3879.918309958622, Loss on the last accepted step: 3879.9183099589045, Step size: 0.9207645165733993\n",
+            "Loss on this step: 3879.91830995856, Loss on the last accepted step: 3879.918309958622, Step size: 0.9207645165733993\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "2025-08-02 07:01:03,434 INFO jaxlogit.mixed_logit: Optimization finished, success = True, final loglike = -3879.92, final gradient max = 7.33e-06, norm = 3.69e-05.\n",
+            "2025-08-02 07:01:03,435 INFO jaxlogit.mixed_logit: Skipping H_inv and grad_n calculation due to skip_std_errs=True\n",
+            "2025-08-02 07:01:03,435 INFO jaxlogit._choice_model: Post fit processing\n",
+            "2025-08-02 07:01:03,438 INFO jaxlogit._choice_model: Optimization terminated successfully.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "    Message: \n",
+            "    Iterations: 147\n",
+            "    Function evaluations: 157\n",
+            "Estimation time= 446.4 seconds\n",
+            "---------------------------------------------------------------------------\n",
+            "Coefficient              Estimate      Std.Err.         z-val         P>|z|\n",
+            "---------------------------------------------------------------------------\n",
+            "pf                     -1.0109002     1.0000000    -1.0109002         0.312    \n",
+            "cl                     -0.2295223     1.0000000    -0.2295223         0.818    \n",
+            "loc                     2.3477364     1.0000000     2.3477364        0.0189 *  \n",
+            "wk                      1.6751214     1.0000000     1.6751214         0.094 .  \n",
+            "tod                    -9.7162856     1.0000000    -9.7162856      4.32e-22 ***\n",
+            "seas                   -9.8762655     1.0000000    -9.8762655      9.19e-23 ***\n",
+            "sd.pf                  -1.3990437     1.0000000    -1.3990437         0.162    \n",
+            "sd.cl                  -0.6755186     1.0000000    -0.6755186         0.499    \n",
+            "sd.loc                  1.7072542     1.0000000     1.7072542        0.0878 .  \n",
+            "sd.wk                   0.9142359     1.0000000     0.9142359         0.361    \n",
+            "sd.tod                  2.4253176     1.0000000     2.4253176        0.0153 *  \n",
+            "sd.seas                 1.3237857     1.0000000     1.3237857         0.186    \n",
+            "---------------------------------------------------------------------------\n",
+            "Significance:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1\n",
+            "\n",
+            "Log-Likelihood= -3879.918\n",
+            "AIC= 7783.837\n",
+            "BIC= 7860.255\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "None"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/usr/lib/python3.10/multiprocessing/popen_fork.py:66: RuntimeWarning: os.fork() was called. os.fork() is incompatible with multithreaded code, and JAX is multithreaded, so this will likely lead to a deadlock.\n",
+            "  self.pid = os.fork()\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "peak memory: 9674.15 MiB, increment: 6727.03 MiB\n"
+          ]
+        }
+      ],
+      "source": [
+        "%%memit\n",
+        "\n",
+        "model = MixedLogit()\n",
+        "res = model.fit(\n",
+        "    X=df[varnames],\n",
+        "    y=df['choice'],\n",
+        "    varnames=varnames,\n",
+        "    ids=df['chid'],\n",
+        "    panels=df['id'],\n",
+        "    alts=df['alt'],\n",
+        "    n_draws=n_draws,\n",
+        "    randvars={'pf': 'n', 'cl': 'n', 'loc': 'n', 'wk': 'n', 'tod': 'n', 'seas': 'n'},\n",
+        "    skip_std_errs=True,  # skip standard errors to speed up the example\n",
+        "    batch_size=2500,\n",
+        ")\n",
+        "display(model.summary())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Peak memory usage came down 16.3GB to 9.7GB, but this is at the cost of runtime, which went from 132s to 446s."
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "mixed_logit_model.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/examples/batching_example.ipynb
+++ b/examples/batching_example.ipynb
@@ -53,7 +53,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Electricity Dataset"
+        "## Electricity Dataset\n",
+        "\n",
+        "From xlogit's examples. Note we skip the calculation of std errors here to speed up test times."
       ]
     },
     {
@@ -93,7 +95,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": null,
       "metadata": {},
       "outputs": [
         {
@@ -328,6 +330,7 @@
         "    n_draws=n_draws,\n",
         "    randvars={'pf': 'n', 'cl': 'n', 'loc': 'n', 'wk': 'n', 'tod': 'n', 'seas': 'n'},\n",
         "    skip_std_errs=True,  # skip standard errors to speed up the example\n",
+        "    # force_positive_chol_diag=False  # do not use softplus transformation for sd. variables\n",
         ")\n",
         "display(model.summary())"
       ]

--- a/jaxlogit/draws.py
+++ b/jaxlogit/draws.py
@@ -5,16 +5,15 @@ import jax.numpy as jnp
 import jax.scipy.stats as jstats
 import numpy as np
 
-from jax._src.numpy.util import promote_args_inexact
-from jax._src.scipy.special import log_ndtr, ndtri
-from jax._src.scipy.stats.truncnorm import _log_gauss_mass
-
 logger = logging.getLogger(__name__)
 
 
 # not implemented in jax.scipy.stats.truncnorm, implemented here based on
 # https://github.com/scipy/scipy/blob/09195e4e02feedd1835a2db335f10e0e151b7909/scipy/stats/_continuous_distns.py#L10313
 # and using https://github.com/jax-ml/jax/blob/main/jax/_src/scipy/stats/truncnorm.py
+# from jax._src.numpy.util import promote_args_inexact
+# from jax._src.scipy.special import log_ndtr, ndtri
+# from jax._src.scipy.stats.truncnorm import _log_gauss_mass
 # def _truncnorm_ppf(q, a, b):
 #     q, a, b = promote_args_inexact("truncnorm_ppf", q, a, b)
 #     q, a, b = jnp.broadcast_arrays(q, a, b)
@@ -216,3 +215,139 @@ def generate_halton_draws(sample_size, n_draws, n_vars, shuffle=False, drop=100,
     ]
     draws = np.stack(draws, axis=1)
     return draws  # (N,Kr,R)
+
+
+def van_der_corput_jax(k, base=2, perm=None):
+    """JAX-traceable van der Corput value for integer k and base, with optional digit permutation."""
+
+    def cond_fun(state):
+        k, val, denom = state
+        return k > 0
+
+    def body_fun(state):
+        k, val, denom = state
+        k, remainder = divmod(k, base)
+        if perm is not None:
+            remainder = perm[remainder]
+        val = val + remainder / denom
+        denom = denom * base
+        return (k, val, denom)
+
+    _, val, _ = jax.lax.while_loop(cond_fun, body_fun, (k, 0.0, base.astype(float)))
+    return val
+
+
+def halton_seq_jax(length, base=2, drop=0, shuffle=False, key=None, scramble=False, perm=None, idxs=None):
+    if idxs is None:
+        idxs = jnp.arange(length + drop)[drop:]
+    ## this is super slow for large numbers so we pass in the idxs directly
+    # MAX_DRAW = 100_000_000_000_000
+    # idxs = jax.lax.dynamic_slice(jnp.arange(MAX_DRAW), (drop,), (length,))
+    if scramble:
+        if perm is None:
+            raise ValueError("A permutation array must be provided for scrambling.")
+        seq = jax.vmap(lambda k: van_der_corput_jax(k, base, perm))(idxs)
+    else:
+        seq = jax.vmap(lambda k: van_der_corput_jax(k, base))(idxs)
+    if shuffle:
+        if key is None:
+            raise ValueError("A JAX PRNG key must be provided for shuffling.")
+        seq = jax.random.permutation(key, seq)
+    return seq
+
+
+# @partial(jax.jit, static_argnames=["sample_size", "n_draws", "n_vars"])
+def get_normal_halton_draws_jax(
+    sample_size, n_draws, n_vars, drop=100, shuffle=False, key=None, primes=None, idxs=None
+):
+    if primes is None:
+        primes = jnp.array(
+            [
+                2,
+                3,
+                5,
+                7,
+                11,
+                13,
+                17,
+                19,
+                23,
+                29,
+                31,
+                37,
+                41,
+                43,
+                47,
+                53,
+                59,
+                61,
+                71,
+                73,
+                79,
+                83,
+                89,
+                97,
+                101,
+                103,
+                107,
+                109,
+                113,
+                127,
+                131,
+                137,
+                139,
+                149,
+                151,
+                157,
+                163,
+                167,
+                173,
+                179,
+                181,
+                191,
+                193,
+                197,
+                199,
+                211,
+                223,
+                227,
+                229,
+                233,
+                239,
+                241,
+                251,
+                257,
+                263,
+                269,
+                271,
+                277,
+                281,
+                283,
+                293,
+                307,
+                311,
+            ]
+        )
+
+    # Optionally split the key for each variable
+    if shuffle:
+        if key is None:
+            raise ValueError("A JAX PRNG key must be provided for shuffling.")
+        keys = jax.random.split(key, n_vars)
+
+    def one_var(i):
+        base = primes[i % len(primes)]
+        k = keys[i] if shuffle else None
+        # if scramble:
+        #     # Generate a random permutation for this base
+        #     perm = jax.random.permutation(k, jnp.arange(base))
+        #     seq = halton_seq_jax(
+        #         sample_size * n_draws, base, drop=drop, shuffle=shuffle, key=k, scramble=True, perm=perm
+        #     )
+        # else:
+        seq = halton_seq_jax(sample_size * n_draws, base, drop=drop, shuffle=shuffle, key=k, idxs=idxs)
+        return jax.scipy.stats.norm.ppf(seq.reshape(sample_size, n_draws))
+
+    draws = jax.vmap(one_var)(jnp.arange(n_vars))
+    draws = jnp.transpose(draws, (1, 0, 2))  # (sample_size, n_vars, n_draws)
+    return draws

--- a/jaxlogit/mixed_logit.py
+++ b/jaxlogit/mixed_logit.py
@@ -28,7 +28,7 @@ class MixedLogit(ChoiceModel):
         self._rvidx = None  # Index of random variables (True when random var)
         self._rvdist = None  # List of mixing distributions of rand vars
 
-    def set_class_variables(
+    def set_data_variables(
         self,
         X,
         y,
@@ -53,7 +53,8 @@ class MixedLogit(ChoiceModel):
         include_correlations,
         force_positive_chol_diag,
         hessian_by_row,
-        finite_diff_hessian,
+        finite_diff_hessian
+        batch_size,
     ):
         # Set class variables to enable simple pickling and running things post-estimation for analysis. This will be
         # replaced by proper database/dataseries structure in the future.
@@ -81,6 +82,7 @@ class MixedLogit(ChoiceModel):
         self.force_positive_chol_diag_raw = (force_positive_chol_diag,)
         self.hessian_by_row_raw = (hessian_by_row,)
         self.finite_diff_hessian_raw = (finite_diff_hessian,)
+        self.batch_size_raw = (batch_size,)
 
     def _setup_input_data(
         self,
@@ -100,6 +102,7 @@ class MixedLogit(ChoiceModel):
         predict_mode=False,
         halton_opts=None,
         include_correlations=False,
+        batch_size=None,
     ):
         # TODO: replace numpy random structure with jax
         if random_state is not None:
@@ -143,11 +146,18 @@ class MixedLogit(ChoiceModel):
         if avail is not None:
             avail = avail.reshape(N, J)
 
-        # Generate draws
-        n_samples = N if panels is None else np.max(panels) + 1
-        draws = generate_draws(n_samples, n_draws, self._rvdist, halton, halton_opts=halton_opts)
-        if panels is not None:
-            draws = draws[panels]  # (N,num_random_params,n_draws)
+        # Generate draws unless batching is enabled
+        if batch_size is None:
+            draws = None
+            logger.debug("Skipping generation of draws because dynamic generation in batches was requested.")
+        else:
+            n_samples = N if panels is None else np.max(panels) + 1
+            logger.debug(f"Generating {n_draws} number of draws for each observation and random variable")
+            draws = generate_draws(n_samples, n_draws, self._rvdist, halton, halton_opts=halton_opts)
+            if panels is not None:
+                draws = draws[panels]  # (N,num_random_params,n_draws)
+            draws = jnp.array(draws)
+            logger.debug(f"Draw generation done, shape of draws: {draws.shape}, number of draws: {n_draws}")
 
         if weights is not None:  # Reshape weights to match input data
             weights = weights.reshape(N, J)[:, 0]
@@ -186,7 +196,7 @@ class MixedLogit(ChoiceModel):
             jnp.array(X),
             None if predict_mode else jnp.array(y),
             jnp.array(panels) if panels is not None else None,
-            jnp.array(draws),
+            draws,
             jnp.array(weights) if weights is not None else None,
             jnp.array(avail) if avail is not None else None,
             Xnames,
@@ -213,6 +223,7 @@ class MixedLogit(ChoiceModel):
         fixedvars=None,
         include_correlations=False,
         predict_mode=False,
+        batch_size=None,
     ):
         # Handle array-like inputs by converting everything to numpy arrays
         (
@@ -236,10 +247,6 @@ class MixedLogit(ChoiceModel):
         )
 
         self._validate_inputs(X, y, alts, varnames, ids, weights, predict_mode=predict_mode)
-
-        logger.info(
-            f"Starting data preparation, including generation of {n_draws} random draws for each random variable and observation."
-        )
 
         self._pre_fit(alts, varnames, maxiter)
 
@@ -270,6 +277,7 @@ class MixedLogit(ChoiceModel):
             predict_mode=predict_mode,
             halton_opts=halton_opts,
             include_correlations=include_correlations,
+            batch_size=batch_size,
         )
 
         # Mask fixed coefficients and set up array with values for the loglikelihood function
@@ -408,10 +416,11 @@ class MixedLogit(ChoiceModel):
         force_positive_chol_diag=True,  # use softplus for the cholesky diagonal elements
         hessian_by_row=True,  # calculate the hessian row by row in a for loop to save memory at the expense of runtime
         finite_diff_hessian=False,
+        batch_size=None,
     ):
         # Set class variables to enable simple pickling and running things post-estimation for analysis. This will be
         # replaced by proper database/dataseries structure in the future.
-        self.set_class_variables(
+        self.set_data_variables(
             X,
             y,
             varnames,
@@ -436,6 +445,7 @@ class MixedLogit(ChoiceModel):
             force_positive_chol_diag,
             hessian_by_row,
             finite_diff_hessian,
+            batch_size,
         )
 
         (
@@ -478,7 +488,41 @@ class MixedLogit(ChoiceModel):
             halton_opts=halton_opts,
             fixedvars=fixedvars,
             include_correlations=include_correlations,
+            batch_size=batch_size,
         )
+
+        # batch_size
+        if panels is None:
+            N = Xdf.shape[0]  # Number of observations
+        else:
+            N = num_panels
+
+        if batch_size is None:
+            logger.info(f"Number of draws: {n_draws}.")
+            num_batches = 1
+            batch_shape = (N, len(rand_idx), n_draws)
+            halton_rand_idxs = None
+        else:
+            assert draws is None
+
+            # TODO: has to be the same shape for all batches and equally divide all rands for jax.lax.scan
+            assert n_draws % batch_size == 0, (
+                f"Batch size {batch_size} does not divide the number of draws {n_draws} evenly "
+                " but this is currently required."
+            )
+            num_batches = len(range(0, n_draws, batch_size))
+            batch_shape = (N, len(rand_idx), batch_size)
+            logger.info(
+                f"Batch size {batch_size} for {n_draws} draws, {num_batches} batches, batch_shape={batch_shape}."
+            )
+
+            # For batched Halton draws, create an index array for the batches to skip to the desired start
+            #  position for each batch - dynamic shapes are not supported in JAX jit.
+            halton_rand_idxs = jnp.zeros((num_batches, batch_shape[0] * batch_shape[2]), dtype=jnp.int64)
+            for i in range(num_batches):
+                drop = 100 + batch_shape[0] * batch_shape[2] * i
+                halton_rand_idxs = halton_rand_idxs.at[i, :].set(jnp.arange(drop, batch_shape[0] * batch_shape[2] + drop, 1))
+            logger.info(f"Shape of halton_rand_idxs: {halton_rand_idxs.shape}, last row: {halton_rand_idxs[-1, :]}.")
 
         fargs = (
             Xdf,
@@ -501,6 +545,7 @@ class MixedLogit(ChoiceModel):
             force_positive_chol_diag,
             rand_idx_stddev,
             rand_idx_chol,
+            halton_rand_idxs,
         )
 
         if idx_ln_dist.shape[0] > 0:
@@ -511,7 +556,6 @@ class MixedLogit(ChoiceModel):
         if panels is not None:
             logger.info(f"Data contains {num_panels} panels.")
 
-        logger.debug(f"Shape of draws: {draws.shape}, number of draws: {n_draws}")
         logger.debug(f"Shape of Xdf: {Xdf.shape}, shape of Xdr: {Xdr.shape}")
 
         tol = {

--- a/jaxlogit/mixed_logit.py
+++ b/jaxlogit/mixed_logit.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from ._choice_model import ChoiceModel, diff_nonchosen_chosen
 from ._optimize import _minimize, gradient, hessian
-from .draws import generate_draws, truncnorm_ppf
+from .draws import generate_draws, truncnorm_ppf, get_normal_halton_draws_jax
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger(__name__)

--- a/jaxlogit/mixed_logit.py
+++ b/jaxlogit/mixed_logit.py
@@ -1006,6 +1006,7 @@ def loglike_individual(
             return carry, None
 
         proba_n, _ = jax.lax.scan(batch_body, jnp.zeros((N,)), halton_rand_idxs)
+        loglik = jnp.log(jnp.clip(proba_n / n_draws, LOG_PROB_MIN, jnp.inf))
 
     else:
         # Utility for random parameters
@@ -1045,7 +1046,7 @@ def loglike_individual(
                 )
             )
 
-    loglik = jnp.log(jnp.clip(proba_n.sum(axis=1) / n_draws, LOG_PROB_MIN, jnp.inf))
+        loglik = jnp.log(jnp.clip(proba_n.sum(axis=1) / n_draws, LOG_PROB_MIN, jnp.inf))
 
     if weights is not None:
         loglik = loglik * weights

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ devtools = [
     'setuptools',
     'uv',
     'ipywidgets',
-    'jupyterlab'
+    'jupyterlab',
+    'memory_profiler',
 ]
 tests = [
     'pytest',


### PR DESCRIPTION
In the current implementation, random draws are generated once upfront and then used throughout estimation. I ran into out of memory issues for a large model, so we here introduce batching of calculations over draws with dynamic re-drawing for every log-likelihood calculation. This preserves memory at the cost of runtime. Note that the underlying loop over batches utilizes jax.lax.scan to avoid unrolling inside jit.